### PR TITLE
fix(release.yml): trigger action only when a new release is from type `published`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
-on: release
+on:
+  release:
+    types: [published]
+    
 name: Deploy to Heroku
 jobs:
   build:


### PR DESCRIPTION
## Description

Making the GitHub action run only in the new git release is from type `published`
